### PR TITLE
Add throw tags to not make iOS crash when request fails

### DIFF
--- a/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
+++ b/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
@@ -4,6 +4,7 @@ import com.mirego.killswitch.viewmodel.KillswitchButtonAction
 import com.mirego.killswitch.viewmodel.KillswitchButtonType
 import com.mirego.killswitch.viewmodel.KillswitchButtonViewData
 import com.mirego.killswitch.viewmodel.KillswitchViewData
+import kotlin.coroutines.cancellation.CancellationException
 import platform.Foundation.NSBundle
 import platform.Foundation.NSLocale
 import platform.Foundation.NSLocaleLanguageCode
@@ -25,7 +26,6 @@ import platform.UIKit.UIViewController
 import platform.UIKit.UIWindowScene
 import platform.UIKit.UIWindowSceneDelegateProtocol
 import platform.UIKit.presentationController
-import kotlin.coroutines.cancellation.CancellationException
 
 class IOSKillswitch {
     @Throws(KillswitchException::class, CancellationException::class)

--- a/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
+++ b/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
@@ -25,8 +25,10 @@ import platform.UIKit.UIViewController
 import platform.UIKit.UIWindowScene
 import platform.UIKit.UIWindowSceneDelegateProtocol
 import platform.UIKit.presentationController
+import kotlin.coroutines.cancellation.CancellationException
 
 class IOSKillswitch {
+    @Throws(KillswitchException::class, CancellationException::class)
     suspend fun engage(key: String, version: String, url: String, language: String): KillswitchViewData? =
         Killswitch.engage(
             key = key,
@@ -35,6 +37,7 @@ class IOSKillswitch {
             language = language
         )
 
+    @Throws(KillswitchException::class, CancellationException::class)
     suspend fun engage(key: String, url: String): KillswitchViewData? =
         Killswitch.engage(
             key = key,


### PR DESCRIPTION
## 📖 Description
Add the same `@Throws(KillswitchException::class, CancellationException::class)` tags that are used in Android. This make sure that the iOS app that uses the killswitch does'nt crash if the request fails.

For example if someone didn't use a right apiKey, the app will simply log a failed request instead of crashing.

