### PR TITLE
iOS: Migrate deprecated openURL method to the new non-deprecated version

### DIFF
--- a/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
+++ b/killswitch/src/iosMain/kotlin/com/mirego/killswitch/IOSKillswitch.kt
@@ -4,6 +4,7 @@ import com.mirego.killswitch.viewmodel.KillswitchButtonAction
 import com.mirego.killswitch.viewmodel.KillswitchButtonType
 import com.mirego.killswitch.viewmodel.KillswitchButtonViewData
 import com.mirego.killswitch.viewmodel.KillswitchViewData
+import kotlin.collections.emptyMap
 import kotlin.coroutines.cancellation.CancellationException
 import platform.Foundation.NSBundle
 import platform.Foundation.NSLocale
@@ -186,7 +187,7 @@ class IOSKillswitch {
                     }
                 } else {
                     NSURL.URLWithString(action.url)?.let {
-                        UIApplication.sharedApplication.openURL(it)
+                        UIApplication.sharedApplication.openURL(it, emptyMap<Any?, Any>()) {}
                     }
                     determineAlertDisplayState()
                 }


### PR DESCRIPTION
## 📖 Description

Migrate the deprecated `openURL` method, which silently fails, to the new `UIApplication.open(_:options:completionHandler:)` method.

The following error was thrown in the console:

> BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).